### PR TITLE
Differentiate between main and offloaded process

### DIFF
--- a/src/ApplicationKernel.php
+++ b/src/ApplicationKernel.php
@@ -20,7 +20,7 @@ use Flows\Processes\Process;
 use Flows\Registries\ProcessRegistry;
 use LogicException;
 
-class Kernel
+class ApplicationKernel
 {
     private ProcessRegistry $processes;
     private EventKernel $events;
@@ -178,5 +178,16 @@ class Kernel
             $process,
             $process->resume($io)
         );
+    }
+
+    /**
+     * 
+     * Current process is offloaded?
+     * 
+     * @return bool TRUE if process is offloaded, FALSE otherwise
+     */
+    public static function isOffloadedProcess(): bool
+    {
+        return defined('OFFLOADED_PROCESS');
     }
 }

--- a/src/Facades/Config.php
+++ b/src/Facades/Config.php
@@ -38,4 +38,9 @@ class Config extends Facade
     {
         return self::$container->get(ConfigService::class)->get('app.config.app');
     }
+
+    public static function getServiceInstance(): ConfigService
+    {
+        return self::$container->get(ConfigService::class);
+    }
 }

--- a/src/Facades/Container.php
+++ b/src/Facades/Container.php
@@ -4,10 +4,17 @@ declare(strict_types=1);
 
 namespace Flows\Facades;
 
+use Flows\Container\Container as ContainerService;
+
 class Container extends Facade
 {
     public static function __callStatic($name, $arguments): mixed
     {
         return self::$container->$name(...$arguments);
+    }
+
+    public static function getServiceInstance(): ContainerService
+    {
+        return self::$container;
     }
 }

--- a/src/Facades/Events.php
+++ b/src/Facades/Events.php
@@ -12,4 +12,9 @@ class Events extends Facade
     {
         return self::$container->get(EventKernel::class)->$name(...$arguments);
     }
+
+    public static function getServiceInstance(): EventKernel
+    {
+        return self::$container->get(EventKernel::class);
+    }
 }

--- a/src/Facades/Facade.php
+++ b/src/Facades/Facade.php
@@ -33,4 +33,12 @@ abstract class Facade
     {
         return isset(static::$ready);
     }
+
+    /**
+     * 
+     * Get the service instance from the container. 
+     * Must be defined in child class.
+     * Acts as getting the service class from the container.
+     */
+    abstract public static function getServiceInstance(): object;
 }

--- a/src/Facades/Logger.php
+++ b/src/Facades/Logger.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flows\Facades;
+
+use Monolog\Logger as MonologLogger;
+
+/**
+ * 
+ * @method static debug(string $message, ?array $extra)  
+ * @method static info(string $message, ?array $extra)  
+ * @method static notice(string $message, ?array $extra)  
+ * @method static warning(string $message, ?array $extra)  
+ * @method static error(string $message, ?array $extra)  
+ * @method static critical(string $message, ?array $extra)  
+ * @method static alert(string $message, ?array $extra)  
+ * @method static emergency(string $message, ?array $extra)  
+ */
+class Logger extends Facade
+{
+    public static function __callStatic($name, $arguments): mixed
+    {
+        return self::$container->get(Logger::class)->$name(...$arguments);
+    }
+
+    public static function getServiceInstance(): MonologLogger
+    {
+        return self::$container->get(MonologLogger::class);
+    }
+}

--- a/src/Facades/Observers.php
+++ b/src/Facades/Observers.php
@@ -12,4 +12,9 @@ class Observers extends Facade
     {
         return self::$container->get(ObserverKernel::class)->$name(...$arguments);
     }
+
+    public static function getServiceInstance(): ObserverKernel
+    {
+        return self::$container->get(ObserverKernel::class);
+    }
 }

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -107,11 +107,12 @@ class Kernel
 
             $orGateIo = new Collection(IO::class);
             foreach ($orProcesses as $orProcess) {
-                $orGateIo->set(
+                $orGateIo->add(
                     $this->processProcess(
                         $orProcess,
                         $gateOrReturn->getIO()
-                    )
+                    ),
+                    $orProcess
                 );
             }
             $this->resumeProcess(

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -115,7 +115,7 @@ class Kernel
                 );
             }
             $this->resumeProcess(
-                $$process,
+                $process,
                 $orGateIo
             );
             return $orGateIo;

--- a/src/OffloadedProcess.php
+++ b/src/OffloadedProcess.php
@@ -2,8 +2,10 @@
 
 declare(strict_types=1);
 
-use Flows\Kernel;
+use Flows\ApplicationKernel;
 use Flows\Registries\ProcessRegistry;
+
+define('OFFLOADED_PROCESS', 0);
 
 require __DIR__ . '/../../../../vendor/autoload.php';
 
@@ -14,12 +16,12 @@ list($process, $contentTerminator, $processIO) = explode('|', $line);
 //
 // What if you need more than one process?
 //
-$kernel = new Kernel();
-$kernel->setProcessRegistry(
+$app = new ApplicationKernel();
+$app->setProcessRegistry(
     (new ProcessRegistry())
         ->add(new $process())
 );
-$return = $kernel->processProcess(
+$return = $app->processProcess(
     $process,
     unserialize(base64_decode($processIO))
 );

--- a/src/OffloadedProcess.php
+++ b/src/OffloadedProcess.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 use Flows\Kernel;
 use Flows\Registries\ProcessRegistry;
 
-require __DIR__ . '/../vendor/autoload.php';
+require __DIR__ . '/../../../../vendor/autoload.php';
 
 ob_start();
 $line = trim(fgets(STDIN));


### PR DESCRIPTION
- Added logger facade
- Bugfix: offloaded process crashed silently because of error in autoloader file path
- Added "OFFLOADED_PROCESS" constant and (application) kernel method to determine if process is main process
- Kernel class renamed to "ApplicationKernel"